### PR TITLE
updated to use t5 model and be able to inference

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ Example for Russian:
 python inference.py \
     --model_name mbart \
     --model_path mbarts\mbart_10000_EN_RU \
-    --language RU
+    --language ru
 ```
 
 and for English:
@@ -52,7 +52,7 @@ and for English:
 python inference.py \
     --model_name mbart \
     --model_path mbarts\mbart_10000_EN_RU \
-    --language EN
+    --language en
 ```
 
 

--- a/inference.py
+++ b/inference.py
@@ -31,7 +31,7 @@ def paraphrase(
         max_length=max_length,
         min_length=int(0.5 * max_length),
         num_beams=beams,
-        forced_bos_token_id=tokenizer.lang_code_to_id[tokenizer.tgt_lang],
+        #forced_bos_token_id=tokenizer.lang_code_to_id[tokenizer.tgt_lang],
     )
     texts = [tokenizer.decode(r, skip_special_tokens=True) for r in result]
 
@@ -47,7 +47,7 @@ if __name__ == "__main__":
         "--model_name",
         type=str,
         required=True,
-        options=["mbart", "mt5"],
+        choices=["mbart", "mt5"],
         help="Specify model type for loading",
     )
     parser.add_argument(
@@ -57,7 +57,7 @@ if __name__ == "__main__":
         "--language",
         type=str,
         required=True,
-        options=["en", "ru"],
+        choices=["en", "ru"],
         help="Specify language for generation",
     )
     args = parser.parse_args()

--- a/mbart_trainer.py
+++ b/mbart_trainer.py
@@ -104,3 +104,4 @@ if __name__ == "__main__":
     print("training started")
     trainer.train()
     model.save_pretrained(f"{args.output_dir}/mbart_{args.max_steps}_{flag}")
+    tokenizer.save_pretrained(f"{args.output_dir}/mbart_{args.max_steps}_{flag}")

--- a/mbart_trainer.py
+++ b/mbart_trainer.py
@@ -25,7 +25,7 @@ if __name__ == "__main__":
     parser.add_argument(
         "--max_steps",
         type=int,
-        default=5_000,
+        default=5000,
         help="maximum learning steps ([1000, 3000, 5000, 10000])",
     )
     parser.add_argument(
@@ -84,12 +84,12 @@ if __name__ == "__main__":
         per_device_train_batch_size=args.batch_size,
         per_device_eval_batch_size=args.batch_size,
         evaluation_strategy="steps",
-        logging_steps=1_000,
+        logging_steps=1000,
         max_steps=args.max_steps,
         learning_rate=args.learning_rate,
         seed=42,
         save_strategy="steps",
-        save_stes=1_000,
+        save_steps=1000,
         warmup_steps=args.warmup_steps,
     )
 

--- a/mt5_trainer.py
+++ b/mt5_trainer.py
@@ -51,13 +51,13 @@ if __name__ == "__main__":
     os.environ["WANDB_DISABLED"] = "true"
     os.environ["CUDA_VISIBLE_DEVICES"] = f"{args.n_device}"
 
-    data = load_data(use_russian=bool(args.use_russian))
+    train_data, tune_data = load_data(use_russian=bool(args.use_russian))
     # train_data = load_only_russian(part='train')
     # tune_data = load_only_russian(part='dev')
 
-    train_ids, tune_ids = train_test_split(
-        data.index, test_size=0.01, random_state=args.seed
-    )
+#     train_ids, tune_ids = train_test_split(
+#         data.index, test_size=0.01, random_state=args.seed
+#     )
 
     model = MT5ForConditionalGeneration.from_pretrained("google/mt5-base")
     tokenizer = MT5Tokenizer.from_pretrained("google/mt5-base")
@@ -66,8 +66,8 @@ if __name__ == "__main__":
     device = torch.device("cuda")
     model = model.to(device)
 
-    trainset = ToxicDataset(data.iloc[train_ids], tokenizer)
-    tuneset = ToxicDataset(data.iloc[tune_ids], tokenizer)
+    trainset = ToxicDataset(train_data, tokenizer)
+    tuneset = ToxicDataset(tune_data, tokenizer)
 
     if args.use_russian == 1:
         flag = "EN_RU"
@@ -97,3 +97,6 @@ if __name__ == "__main__":
         tokenizer=tokenizer,
     )
     trainer.train()
+    print("training started")
+    model.save_pretrained(f"{args.output_dir}/mt5_{args.max_steps}_{flag}")
+    tokenizer.save_pretrained(f"{args.output_dir}/mt5_{args.max_steps}_{flag}")


### PR DESCRIPTION
Two bugs prevent from using mT5 and running the inference.py in general:

1) 'T5Tokenizer' object has no attribute 'lang_code_to_id'
Solution: comment out the 34st line since 'forced_bos_token_id' argument is optional and 'lang_code_to_id' is not native to mT5Tokenizer

2) __init__() got an unexpected keyword argument 'options'
Solution: change 'options' argument to 'choices'. See https://docs.python.org/3/library/argparse.html#choices